### PR TITLE
chore: disable Blankary support due to platform limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Chytanka supports opening episodes from the following platforms:
 
-- [x] [Blankary](https://blankary.com)
+- [x] ~~[Blankary](https://blankary.com)~~ (image support has been discontinued)
 - [x] [Comick](https://comick.io)
 - [x] [Imgur](https://imgur.com)
 - [x] [Mangadex](https://mangadex.org)

--- a/src/app/@site-modules/zenko/zenko.service.ts
+++ b/src/app/@site-modules/zenko/zenko.service.ts
@@ -32,7 +32,7 @@ export class ZenkoService {
 
       images: (data.pages.map((item: any) => {
         return {
-          src: item.imgUrl
+          src: item.imgUrl || item.content
         };
       })).filter((i: any) => i.src).map((img: any) => { return { src: this.proxy.proxyUrl(`https://zenko.b-cdn.net/${img.src}?optimizer=image&width=900&quality=90&height=auto`) } })
       

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -31,7 +31,7 @@ export const BLANKARY_PATH = 'blankary';
 export const FILE_PATH = 'file';
 
 const linkParserMod: LoadChildrenCallback = () => import('./link-parser/link-parser.module').then(m => m.LinkParserModule)
-const blankaryMod = () => import('./@site-modules/blankary/blankary-shell.component')
+// const blankaryMod = () => import('./@site-modules/blankary/blankary-shell.component')
 const comickMod = () => import('./@site-modules/comick/comick-shell.component')
 const imgurMod = () => import('./@site-modules/imgur/imgur-shell.component')
 const mangadexMod = () => import('./@site-modules/mangadex/mangadex-shell.component')
@@ -49,7 +49,7 @@ const COMPARE_OUTLET_NAME = 'right'
 type LoadComponentType = (() => Type<unknown> | Observable<Type<unknown> | DefaultExport<Type<unknown>>> | Promise<Type<unknown> | DefaultExport<Type<unknown>>>) | undefined;
 
 const siteModulesMap = new Map<string, LoadComponentType>()
-  .set(BLANKARY_PATH + '/:id', blankaryMod)
+  // .set(BLANKARY_PATH + '/:id', blankaryMod)
   .set(COMICK_PATH + '/:id', comickMod)
   .set(IMGUR_PATH + '/:id', imgurMod)
   .set(MANGADEX_PATH + '/:id', mangadexMod)

--- a/src/app/link-parser/data-access/link-parser.service.ts
+++ b/src/app/link-parser/data-access/link-parser.service.ts
@@ -17,7 +17,7 @@ export class LinkParserService {
     "Comick",
     "NHentai",
     "Yandere Pools",
-    "Blankary",
+    // "Blankary",
     "Pixiv"
   ].sort())
 

--- a/src/app/link-parser/ui/parser-form/parser-form.component.ts
+++ b/src/app/link-parser/ui/parser-form/parser-form.component.ts
@@ -44,7 +44,7 @@ export class ParserFormComponent {
     this.parser.parsers.push(new ComickLinkParser)
     this.parser.parsers.push(new YandereParser)
     this.parser.parsers.push(new PixivLinkParser)
-    this.parser.parsers.push(new BlankaryLinkParser)
+    // this.parser.parsers.push(new BlankaryLinkParser)
     this.parser.parsers.push(new JsonLinkParser)
   }
 
@@ -107,7 +107,7 @@ export class ParserFormComponent {
     comick: '//comick.io/favicon.ico',
     yandere: '//yande.re/favicon.ico',
     pixiv: '//pixiv.net/favicon.ico',
-    blankary: '//blankary.com/favicon.ico',
+    // blankary: '//blankary.com/favicon.ico',
     read: 'data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🗯️</text></svg>'
   }
 }

--- a/src/app/list/list-shell/list-shell.component.ts
+++ b/src/app/list/list-shell/list-shell.component.ts
@@ -92,7 +92,7 @@ export class ListShellComponent {
     this.parser.parsers.push(new ComickLinkParser)
     this.parser.parsers.push(new YandereParser)
     this.parser.parsers.push(new PixivLinkParser)
-    this.parser.parsers.push(new BlankaryLinkParser)
+    // this.parser.parsers.push(new BlankaryLinkParser)
     this.parser.parsers.push(new JsonLinkParser)
   }
 


### PR DESCRIPTION
fix: zenko image href